### PR TITLE
캘린더, 카테고리 UI 수정 & 거래 추가 및 업데이트를 위한 네트워크 요청

### DIFF
--- a/db-server/DATA.json
+++ b/db-server/DATA.json
@@ -1,7 +1,7 @@
 {
     "accountLogs": [
         {
-            "log_id": 1,
+            "id": 1,
             "member_id": 2,
             "deposit": 3000000,
             "withdraw": 0,
@@ -11,7 +11,7 @@
             "balance": 3000000
         },
         {
-            "log_id": 2,
+            "id": 2,
             "member_id": 1,
             "deposit": 0,
             "withdraw": 1000,
@@ -21,7 +21,7 @@
             "balance": 2999000
         },
         {
-            "log_id": 3,
+            "id": 3,
             "member_id": 1,
             "deposit": 0,
             "withdraw": 10000,
@@ -31,7 +31,7 @@
             "balance": 2989000
         },
         {
-            "log_id": 4,
+            "id": 4,
             "member_id": 3,
             "deposit": 0,
             "withdraw": 5000,
@@ -41,7 +41,7 @@
             "balance": 2984000
         },
         {
-            "log_id": 5,
+            "id": 5,
             "member_id": 4,
             "deposit": 0,
             "withdraw": 1000,
@@ -51,7 +51,7 @@
             "balance": 2983000
         },
         {
-            "log_id": 6,
+            "id": 6,
             "member_id": 4,
             "deposit": 0,
             "withdraw": 6000,
@@ -61,7 +61,7 @@
             "balance": 2977000
         },
         {
-            "log_id": 7,
+            "id": 7,
             "member_id": 5,
             "deposit": 0,
             "withdraw": 700000,
@@ -71,7 +71,7 @@
             "balance": 2277000
         },
         {
-            "log_id": 8,
+            "id": 8,
             "member_id": 1,
             "deposit": 0,
             "withdraw": 3000,
@@ -81,7 +81,7 @@
             "balance": 2274000
         },
         {
-            "log_id": 9,
+            "id": 9,
             "member_id": 1,
             "deposit": 0,
             "withdraw": 2000,
@@ -91,7 +91,7 @@
             "balance": 2272000
         },
         {
-            "log_id": 10,
+            "id": 10,
             "member_id": 2,
             "deposit": 0,
             "withdraw": 5000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "bootstrap": "^5.3.3",
         "pinia": "^2.1.7",
         "vue": "^3.4.21",
-        "vue-router": "^4.3.0"
+        "vue-router": "^4.3.0",
+        "vue3-datepicker": "^0.4.0"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.4",
@@ -33,6 +34,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
+      "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -852,6 +864,21 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1091,6 +1118,11 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
     "node_modules/rollup": {
       "version": "4.18.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
@@ -1221,6 +1253,20 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue3-datepicker": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/vue3-datepicker/-/vue3-datepicker-0.4.0.tgz",
+      "integrity": "sha512-o0/y4yuZZc0DXYhiAlX8Znrkm/zvkeYuyV9PUt0UAvwxkno2jqMS388jVUa9Ns+a2s2pOAAybyXo5uQ9YAIwVw==",
+      "dependencies": {
+        "date-fns": "^2.22.1"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "bootstrap": "^5.3.3",
     "pinia": "^2.1.7",
     "vue": "^3.4.21",
-    "vue-router": "^4.3.0"
+    "vue-router": "^4.3.0",
+    "vue3-datepicker": "^0.4.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",

--- a/src/components/DealUpdate.vue
+++ b/src/components/DealUpdate.vue
@@ -5,16 +5,24 @@
             <div class="mb-3 mt-3">
                 <label for="deatil" class="form-label display-7">거래명</label>
                 <input type="text" class="form-control" id="deatil" placeholder="거래명을 입력하세요" required
-                        v-model="trading.deatil">
+                    v-model="trading.deatil">
             </div>
-            <div class="mb-3">
-                <label for="category" class="form-label">카테고리</label>
-                <input type="text" class="form-control" id="category" placeholder="카테고리를 입력하세요" required
-                        v-model="trading.category">
+            <div class="mb-3 mt-3">
+                <label for="category" class="col-sm-2 col-form-label">카테고리</label>
+                <select class="form-control" id="category" v-model="trading.category" required>
+                    <option value="">카테고리를 선택하세요</option>
+                    <option value="월급">월급</option>
+                    <option value="생필품">생필품</option>
+                    <option value="식비">식비</option>
+                    <option value="여행">여행</option>
+                    <option value="의료">의료</option>
+                </select>
             </div>
             <div class="mb-3">
                 <label for="date" class="form-label">날짜 선택</label>
-                <!-- <Datepicker v-model="trading.date" /> -->  <!-- TODO: <b-form-datepicker>로 변경 예정 -->
+                <div :style="datepickerStyles">
+                    <Datepicker v-model="trading.date" :format="'dd-MM-yyyy'" class="form-control" />
+                </div>
             </div>
             <div class="mb-3">
                 <div class="d-flex ">
@@ -25,63 +33,87 @@
                     </select>
                 </div>
                 <input type="number" class="form-control mt-2" id="expenses" placeholder="1,000" required
-                        v-model="trading.expenses">
+                    v-model="trading.expenses">
             </div>
             <div class="mb-3">
                 <label for="balance" class="form-label">잔액</label>
                 <input type="number" class="form-control" id="balance" placeholder="1,000" required
-                        v-model="trading.balance">
+                    v-model="trading.balance">
             </div>
             <div class="d-grid">
-                <button class="btn btn-dark" type="submit">Button</button>    
+                <button class="btn btn-dark" type="submit">수정하기</button>
             </div>
         </form>
     </div>
 </template>
 <script>
 import { reactive } from 'vue'
-// import axios from 'axios'
-// import Datepicker from 'vue3-datepicker';    // 변경 예정
+import Datepicker from 'vue3-datepicker';
+import axios from 'axios'
 
 export default {
-    name: 'DealUpdate', //주소록 추가
-    // components: {
-    //     Datepicker
-    // },
+    name: 'DealUpdate',
+    components: {
+        Datepicker
+    },
     setup() {
+        //TODO: Props로 받아오는 데이터로 수정 필요
         let trading = reactive({
-            id: Date.now(),     //TODO: id의 마지막 id값 + 1 으로 변경
+            id: 0,
+            date: new Date(),
             deatil: '',
             category: '',
-            date: new Date(),
             tradingType: '',
             expenses: '',
             balance: ''
         })
 
+        const datepickerStyles = {
+            '--vdp-bg-color': '#f0f8ff',
+            '--vdp-text-color': '#000',
+            '--vdp-highlight-color': '#ff4500'
+        }
+
         // 거래 내역 업데이트(PUT)
         const updateSubmitHandler = async (e) => {
             const url = `http://localhost:3001/accountLogs`
-            const data = trading
-            const dataJson = JSON.stringify(data)
+            const logDate = trading.date
+            const year = logDate.getFullYear()
+            const month = String(logDate.getMonth() + 1).padStart(2, '0')
+            const day = String(logDate.getDate()).padStart(2, '0')
+            const dateString = `${year}-${month}-${day}`
+
+            const payload = {
+                id: 0,
+                member_id: trading.id,
+                deposit: trading.tradingType === 'Deposit' ? trading.expenses : 0,
+                withdraw: trading.tradingType === 'Withdrawal' ? trading.expenses : 0,
+                category: trading.category,
+                contents: trading.detail,
+                reg_date: dateString,
+                balance: trading.balance,
+            };
+
+            // const data = trading
+            // const dataJson = JSON.stringify(data)
 
             try {
-                // const response = await axios.get(url)
-                // const ids = response.data.map((accountLogs) => {
-                //     return accountLogs.id
-                // })
+                const response = await axios.get(url)
+                const ids = response.data.map((accountLogs) => {
+                    return accountLogs.id
+                })
 
                 // const maxId = ids.length == 0 ? 0 : Math.max(...ids)
                 // trading.id = maxId + 1
 
                 // await axios.put(url, data, {"Content-Type": "application/json"})
-            } catch(err) {
+            } catch (err) {
                 alert(err)
                 console.log("err 발생 입니다.")
             }
         }
 
-        return { trading, updateSubmitHandler }
+        return { trading, updateSubmitHandler, Datepicker, datepickerStyles }
     }
 }
 </script>
@@ -89,9 +121,12 @@ export default {
 .form-label {
     font-size: 1.25em;
 }
+
 .form-select {
     font-size: 1.25em;
     width: auto;
-
+    border-width: 0;
+    position: relative;
+    left: -8px;
 }
 </style>

--- a/src/components/DealUpdate.vue
+++ b/src/components/DealUpdate.vue
@@ -1,51 +1,57 @@
 <template>
-    <div class="mx-3 my-3">
-        <h1>내역 수정</h1>
-        <form class="create" @submit.prevent="updateSubmitHandler">
-            <div class="mb-3 mt-3">
-                <label for="deatil" class="form-label display-7">거래명</label>
-                <input type="text" class="form-control" id="deatil" placeholder="거래명을 입력하세요" required
-                    v-model="trading.deatil">
-            </div>
-            <div class="mb-3 mt-3">
-                <label for="category" class="col-sm-2 col-form-label">카테고리</label>
-                <select class="form-control" id="category" v-model="trading.category" required>
-                    <option value="">카테고리를 선택하세요</option>
-                    <option value="월급">월급</option>
-                    <option value="생필품">생필품</option>
-                    <option value="식비">식비</option>
-                    <option value="여행">여행</option>
-                    <option value="의료">의료</option>
-                </select>
-            </div>
-            <div class="mb-3">
-                <label for="date" class="form-label">날짜 선택</label>
-                <div :style="datepickerStyles">
-                    <Datepicker v-model="trading.date" :format="'dd-MM-yyyy'" class="form-control" />
+    <div class="modal-container">
+        <div class="modal-content">
+            <button class="close-button" @click="sendClose">
+                <i class="fa fa-times" aria-hidden="true"></i>
+            </button>
+            <h1>내역 수정</h1>
+            <form class="create" @submit.prevent="updateSubmitHandler">
+                <div class="mb-3 mt-3">
+                    <label for="detail" class="form-label display-7">거래명</label>
+                    <input type="text" class="form-control" id="detail" placeholder="거래명을 입력하세요" required
+                        v-model="trading.detail">
                 </div>
-            </div>
-            <div class="mb-3">
-                <div class="d-flex ">
-                    <select class="form-select form-select-sm" style="" v-model="trading.tradingType" required>
-                        <option disabled value="">거래</option>
-                        <option value="deposit">입금</option>
-                        <option value="withdrawal">출금</option>
+                <div class="mb-3 mt-3">
+                    <label for="category" class="col-sm-2 col-form-label">카테고리</label>
+                    <select class="form-control" id="category" v-model="trading.category" required>
+                        <option value="">카테고리를 선택하세요</option>
+                        <option value="월급">월급</option>
+                        <option value="생필품">생필품</option>
+                        <option value="식비">식비</option>
+                        <option value="여행">여행</option>
+                        <option value="의료">의료</option>
                     </select>
                 </div>
-                <input type="number" class="form-control mt-2" id="expenses" placeholder="1,000" required
-                    v-model="trading.expenses">
-            </div>
-            <div class="mb-3">
-                <label for="balance" class="form-label">잔액</label>
-                <input type="number" class="form-control" id="balance" placeholder="1,000" required
-                    v-model="trading.balance">
-            </div>
-            <div class="d-grid">
-                <button class="btn btn-dark" type="submit">수정하기</button>
-            </div>
-        </form>
+                <div class="mb-3">
+                    <label for="date" class="form-label">날짜 선택</label>
+                    <div :style="datepickerStyles">
+                        <Datepicker v-model="trading.date" :format="'dd-MM-yyyy'" class="form-control" />
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <div class="d-flex">
+                        <select class="form-select form-select-sm" v-model="trading.tradingType" required>
+                            <option disabled value="">거래</option>
+                            <option value="deposit">입금</option>
+                            <option value="withdrawal">출금</option>
+                        </select>
+                    </div>
+                    <input type="number" class="form-control mt-2" id="expenses" placeholder="1,000" required
+                        v-model="trading.expenses">
+                </div>
+                <div class="mb-3">
+                    <label for="balance" class="form-label">잔액</label>
+                    <input type="number" class="form-control" id="balance" placeholder="1,000" required
+                        v-model="trading.balance">
+                </div>
+                <div class="d-grid">
+                    <button class="btn btn-dark" type="submit">수정하기</button>
+                </div>
+            </form>
+        </div>
     </div>
 </template>
+
 <script>
 import { reactive } from 'vue'
 import Datepicker from 'vue3-datepicker';
@@ -61,7 +67,7 @@ export default {
         let trading = reactive({
             id: 0,
             date: new Date(),
-            deatil: '',
+            detail: '',
             category: '',
             tradingType: '',
             expenses: '',
@@ -103,21 +109,59 @@ export default {
                     return accountLogs.id
                 })
 
-                // const maxId = ids.length == 0 ? 0 : Math.max(...ids)
-                // trading.id = maxId + 1
-
                 // await axios.put(url, data, {"Content-Type": "application/json"})
+                
+                // TODO: 수정요청 완료 후 모달창 닫기
+                // emit('sendClose')
             } catch (err) {
                 alert(err)
                 console.log("err 발생 입니다.")
             }
         }
 
-        return { trading, updateSubmitHandler, Datepicker, datepickerStyles }
+        // [모달창 닫기]: emit
+        const sendClose = () => {
+            alert('sendClose')
+            // emit('sendClose')
+        }
+
+        return { trading, updateSubmitHandler, Datepicker, datepickerStyles, sendClose }
     }
 }
 </script>
 <style scoped>
+.modal-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 10px;
+    width: 80%;
+    max-width: 500px;
+    position: relative;
+}
+
+.close-button {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 1.5em;
+    cursor: pointer;
+}
+
 .form-label {
     font-size: 1.25em;
 }


### PR DESCRIPTION
# 작업사항
- a3bcd40: 패키지 추가
  - vue3-datepicker package를 추가했습니다.
- 164e55d
  - UI 변경
    - DatePicker를 vue3-datepicker package로 변경
    - 카테고리 선택에 대한 TextField를 Selector로 변경
  - 네트워크 요청 추가(axios + json server)
    - 거래 내역 추가 - POST
        id 체크: 가장 마지막 log의 id값 + 1
        balance 체크: 가장 최신의 잔액값을 찾아서 갱신
    - 내역 수정 - PUT
        사용자 입력 정보를 받아 업데이트를 요청
- d778fd3
  - Modal
    - 내역 수정 화면을 Modal 형태로 UI로 변경
    - 창을 닫을 수 있도록 emit 추가

# 스크린샷
- 거래 추가 화면
  <img width="500" alt="image" src="https://github.com/chuseok/financial-ledger/assets/57349859/61850671-8ca3-44fd-8106-88f7b39fde6d"><br/>

  <img height="200" alt="image" src="https://github.com/chuseok/financial-ledger/assets/57349859/e8c1eddf-1a5d-4723-ae71-4e459aff7558">
  <img height="200" alt="image" src="https://github.com/chuseok/financial-ledger/assets/57349859/6c2182c0-1115-4171-b96d-f1de99ed68c3">

- 내역 수정 모달
  <img width="500" alt="image" src="https://github.com/chuseok/financial-ledger/assets/57349859/e7a00772-700a-4a4b-a654-f66fb4475605">

# 해야할 것
- 거래 내역 추가
  - 라우팅 적용
  - 현재 member_id를 받아서 처리하도록 변경
- 내역 수정
  - 기존 내역 정보를 props로 전달받도록 수정
  - 받아온 데이터로 PUT(수정) 요청